### PR TITLE
fix: JsonUtil 패키지 경로 불일치 문제 수정

### DIFF
--- a/springProject/src/main/java/com/teambind/coupon/common/util/json/JsonUtil.java
+++ b/springProject/src/main/java/com/teambind/coupon/common/util/json/JsonUtil.java
@@ -1,4 +1,4 @@
-package com.teambind.springproject.common.util.json;
+package com.teambind.coupon.common.util.json;
 
 public interface JsonUtil {
 	String toJson(Object object);

--- a/springProject/src/main/java/com/teambind/coupon/common/util/json/JsonUtilWithObjectMapper.java
+++ b/springProject/src/main/java/com/teambind/coupon/common/util/json/JsonUtilWithObjectMapper.java
@@ -1,6 +1,5 @@
 package com.teambind.coupon.common.util.json;
 
-import com.teambind.springproject.common.util.json.JsonUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Component;
 


### PR DESCRIPTION
## Summary
JsonUtil 인터페이스와 구현체의 패키지 경로 불일치 문제를 수정했습니다.

## Problem
- JsonUtil 인터페이스: `com.teambind.springproject.common.util.json`
- JsonUtilWithObjectMapper 구현체: `com.teambind.coupon.common.util.json`
- 서로 다른 패키지로 인해 컴파일 오류 발생

## Solution
- 두 파일 모두 `com.teambind.coupon.common.util.json` 패키지로 통일
- 불필요한 import 제거

## Changes
- JsonUtil.java: 패키지 경로 수정
- JsonUtilWithObjectMapper.java: import 정리

## Test
- 빌드 성공 확인
- 컴파일 오류 해결 확인