### PR TITLE
feat: 쿠폰 만료 처리 자동화 구현

### DIFF
--- a/springProject/src/main/java/com/teambind/coupon/adapter/out/persistence/entity/CouponIssueEntity.java
+++ b/springProject/src/main/java/com/teambind/coupon/adapter/out/persistence/entity/CouponIssueEntity.java
@@ -85,4 +85,27 @@ public class CouponIssueEntity extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "policy_id", insertable = false, updatable = false)
     private CouponPolicyEntity policy;
+
+    /**
+     * 쿠폰 예약 취소 (롤백)
+     * RESERVED 상태를 다시 ISSUED 상태로 변경
+     */
+    public void rollback() {
+        if (this.status == CouponStatus.RESERVED) {
+            this.status = CouponStatus.ISSUED;
+            this.reservationId = null;
+            this.reservedAt = null;
+        }
+    }
+
+    /**
+     * 쿠폰 만료 처리
+     * ISSUED 또는 RESERVED 상태를 EXPIRED로 변경
+     */
+    public void expire() {
+        if (this.status == CouponStatus.ISSUED || this.status == CouponStatus.RESERVED) {
+            this.status = CouponStatus.EXPIRED;
+            this.expiredAt = LocalDateTime.now();
+        }
+    }
 }

--- a/springProject/src/main/java/com/teambind/coupon/adapter/out/persistence/repository/CouponIssueRepository.java
+++ b/springProject/src/main/java/com/teambind/coupon/adapter/out/persistence/repository/CouponIssueRepository.java
@@ -69,6 +69,30 @@ public interface CouponIssueRepository extends JpaRepository<CouponIssueEntity, 
     List<CouponIssueEntity> findExpiredCoupons(@Param("now") LocalDateTime now);
 
     /**
+     * 만료 대상 쿠폰 페이징 조회 (배치 처리용)
+     */
+    @Query("SELECT ci FROM CouponIssueEntity ci " +
+           "WHERE ci.status IN ('ISSUED', 'RESERVED') " +
+           "AND ci.expiresAt < :now")
+    Page<CouponIssueEntity> findExpiredCouponsWithPaging(
+            @Param("now") LocalDateTime now,
+            Pageable pageable
+    );
+
+    /**
+     * 쿠폰 상태를 만료로 일괄 업데이트
+     */
+    @Modifying
+    @Query("UPDATE CouponIssueEntity ci " +
+           "SET ci.status = 'EXPIRED', ci.expiredAt = :now " +
+           "WHERE ci.id IN :ids " +
+           "AND ci.status IN ('ISSUED', 'RESERVED')")
+    int updateToExpiredBatch(
+            @Param("ids") List<Long> ids,
+            @Param("now") LocalDateTime now
+    );
+
+    /**
      * 쿠폰 ID와 사용자 ID로 조회
      */
     @Query("SELECT ci FROM CouponIssueEntity ci " +

--- a/springProject/src/main/java/com/teambind/coupon/application/scheduler/CouponExpiryScheduler.java
+++ b/springProject/src/main/java/com/teambind/coupon/application/scheduler/CouponExpiryScheduler.java
@@ -1,0 +1,183 @@
+package com.teambind.coupon.application.scheduler;
+
+import com.teambind.coupon.adapter.out.persistence.entity.CouponIssueEntity;
+import com.teambind.coupon.adapter.out.persistence.repository.CouponIssueRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 쿠폰 만료 처리 스케줄러
+ * 주기적으로 만료된 쿠폰의 상태를 업데이트합니다.
+ * DB에서 삭제하지 않고 상태만 EXPIRED로 변경하여 이력을 보존합니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CouponExpiryScheduler {
+
+    private final CouponIssueRepository couponIssueRepository;
+
+    @Value("${coupon.scheduler.expiry.batch-size:100}")
+    private int batchSize;
+
+    @Value("${coupon.scheduler.expiry.enabled:true}")
+    private boolean schedulerEnabled;
+
+    /**
+     * 매일 자정에 만료된 쿠폰 상태 업데이트
+     * cron: 초 분 시 일 월 요일
+     */
+    @Scheduled(cron = "${coupon.scheduler.expiry.cron:0 0 0 * * *}")
+    @Transactional
+    public void processExpiredCoupons() {
+        if (!schedulerEnabled) {
+            log.info("쿠폰 만료 스케줄러가 비활성화되어 있습니다.");
+            return;
+        }
+
+        log.info("쿠폰 만료 처리 시작");
+        LocalDateTime now = LocalDateTime.now();
+
+        try {
+            int totalProcessed = processExpiredCouponsInBatches(now);
+            log.info("쿠폰 만료 처리 완료 - 총 {}개 쿠폰 상태 업데이트", totalProcessed);
+        } catch (Exception e) {
+            log.error("쿠폰 만료 처리 중 오류 발생", e);
+            throw e;
+        }
+    }
+
+    /**
+     * 배치 단위로 만료 쿠폰 처리
+     * 대량의 데이터를 효율적으로 처리하기 위해 페이징 사용
+     */
+    private int processExpiredCouponsInBatches(LocalDateTime now) {
+        int totalProcessed = 0;
+        int pageNumber = 0;
+        Page<CouponIssueEntity> page;
+
+        do {
+            // 배치 크기만큼 조회
+            Pageable pageable = PageRequest.of(pageNumber, batchSize);
+            page = couponIssueRepository.findExpiredCouponsWithPaging(now, pageable);
+
+            if (page.hasContent()) {
+                // 배치 업데이트
+                int processed = updateExpiredCoupons(page.getContent(), now);
+                totalProcessed += processed;
+
+                log.debug("배치 {} 처리 완료: {}개 쿠폰 만료 처리", pageNumber + 1, processed);
+            }
+
+            pageNumber++;
+        } while (page.hasNext());
+
+        return totalProcessed;
+    }
+
+    /**
+     * 쿠폰 상태를 EXPIRED로 일괄 업데이트
+     */
+    private int updateExpiredCoupons(List<CouponIssueEntity> expiredCoupons, LocalDateTime now) {
+        if (expiredCoupons.isEmpty()) {
+            return 0;
+        }
+
+        // 쿠폰 ID 목록 추출
+        List<Long> couponIds = expiredCoupons.stream()
+                .map(CouponIssueEntity::getId)
+                .collect(Collectors.toList());
+
+        // 배치 업데이트 실행
+        int updatedCount = couponIssueRepository.updateToExpiredBatch(couponIds, now);
+
+        // 업데이트된 쿠폰 정보 로깅
+        if (log.isDebugEnabled()) {
+            log.debug("만료 처리된 쿠폰 ID: {}", couponIds);
+        }
+
+        // 사용자별 알림 발송 (추후 구현 가능)
+        // notificationService.sendExpiryNotifications(expiredCoupons);
+
+        return updatedCount;
+    }
+
+    /**
+     * 즉시 만료 처리 실행 (테스트 및 수동 실행용)
+     */
+    @Transactional
+    public int processExpiredCouponsManually() {
+        log.info("쿠폰 만료 수동 처리 시작");
+        LocalDateTime now = LocalDateTime.now();
+
+        try {
+            int totalProcessed = processExpiredCouponsInBatches(now);
+            log.info("쿠폰 만료 수동 처리 완료 - 총 {}개 쿠폰 상태 업데이트", totalProcessed);
+            return totalProcessed;
+        } catch (Exception e) {
+            log.error("쿠폰 만료 수동 처리 중 오류 발생", e);
+            throw e;
+        }
+    }
+
+    /**
+     * 예약 타임아웃 처리
+     * 30분이 지난 예약 상태 쿠폰을 다시 ISSUED 상태로 복구
+     */
+    @Scheduled(cron = "${coupon.scheduler.reservation-timeout.cron:0 */5 * * * *}")
+    @Transactional
+    public void processReservationTimeouts() {
+        if (!schedulerEnabled) {
+            return;
+        }
+
+        log.debug("예약 타임아웃 처리 시작");
+        LocalDateTime timeoutThreshold = LocalDateTime.now().minusMinutes(30);
+
+        List<CouponIssueEntity> timeoutReservations =
+                couponIssueRepository.findTimeoutReservations(timeoutThreshold);
+
+        if (!timeoutReservations.isEmpty()) {
+            for (CouponIssueEntity reservation : timeoutReservations) {
+                // 예약 취소하고 ISSUED 상태로 복구
+                reservation.rollback();
+                couponIssueRepository.save(reservation);
+            }
+
+            log.info("예약 타임아웃 처리 완료 - {}개 쿠폰 복구", timeoutReservations.size());
+        }
+    }
+
+    /**
+     * 스케줄러 상태 조회
+     */
+    public SchedulerStatus getStatus() {
+        return SchedulerStatus.builder()
+                .enabled(schedulerEnabled)
+                .batchSize(batchSize)
+                .lastProcessedTime(LocalDateTime.now())
+                .build();
+    }
+
+    /**
+     * 스케줄러 상태 정보
+     */
+    @lombok.Builder
+    @lombok.Getter
+    public static class SchedulerStatus {
+        private final boolean enabled;
+        private final int batchSize;
+        private final LocalDateTime lastProcessedTime;
+    }
+}

--- a/springProject/src/main/java/com/teambind/coupon/config/SchedulerConfig.java
+++ b/springProject/src/main/java/com/teambind/coupon/config/SchedulerConfig.java
@@ -1,0 +1,29 @@
+package com.teambind.coupon.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+/**
+ * 스케줄러 설정
+ * Spring의 @Scheduled 어노테이션 기반 스케줄링 활성화
+ */
+@Configuration
+@EnableScheduling
+public class SchedulerConfig implements SchedulingConfigurer {
+
+    /**
+     * 스케줄러 스레드 풀 설정
+     * 여러 스케줄된 작업이 동시에 실행될 수 있도록 설정
+     */
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+        taskScheduler.setPoolSize(5);  // 동시 실행 가능한 스케줄 작업 수
+        taskScheduler.setThreadNamePrefix("coupon-scheduler-");
+        taskScheduler.initialize();
+        taskRegistrar.setTaskScheduler(taskScheduler);
+    }
+}

--- a/springProject/src/main/resources/application.yaml
+++ b/springProject/src/main/resources/application.yaml
@@ -101,9 +101,15 @@ coupon:
     max-failures: 10
   scheduler:
     timeout:
-      
       enabled: true
       cron: "0 * * * * *"  # 매 1분마다 실행
+    expiry:
+      enabled: true
+      batch-size: 100
+      cron: "0 0 0 * * *"  # 매일 자정에 실행
+    reservation-timeout:
+      enabled: true
+      cron: "0 */5 * * * *"  # 5분마다 실행
 
 kafka:
   topics:

--- a/springProject/src/test/java/com/teambind/coupon/application/scheduler/CouponExpirySchedulerTest.java
+++ b/springProject/src/test/java/com/teambind/coupon/application/scheduler/CouponExpirySchedulerTest.java
@@ -1,0 +1,272 @@
+package com.teambind.coupon.application.scheduler;
+
+import com.teambind.coupon.adapter.out.persistence.entity.CouponIssueEntity;
+import com.teambind.coupon.adapter.out.persistence.repository.CouponIssueRepository;
+import com.teambind.coupon.domain.model.CouponStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * 쿠폰 만료 스케줄러 테스트
+ */
+@ExtendWith(MockitoExtension.class)
+class CouponExpirySchedulerTest {
+
+    @InjectMocks
+    private CouponExpiryScheduler scheduler;
+
+    @Mock
+    private CouponIssueRepository couponIssueRepository;
+
+    @BeforeEach
+    void setUp() {
+        // 배치 크기와 스케줄러 활성화 설정
+        ReflectionTestUtils.setField(scheduler, "batchSize", 10);
+        ReflectionTestUtils.setField(scheduler, "schedulerEnabled", true);
+    }
+
+    @Test
+    @DisplayName("만료된 쿠폰들이 배치로 처리되어야 한다")
+    void processExpiredCoupons_shouldProcessInBatches() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        List<CouponIssueEntity> expiredCoupons = createExpiredCoupons(25); // 25개 쿠폰
+
+        // 3개의 페이지로 분할 (10, 10, 5)
+        Page<CouponIssueEntity> page1 = new PageImpl<>(
+                expiredCoupons.subList(0, 10),
+                PageRequest.of(0, 10),
+                25
+        );
+        Page<CouponIssueEntity> page2 = new PageImpl<>(
+                expiredCoupons.subList(10, 20),
+                PageRequest.of(1, 10),
+                25
+        );
+        Page<CouponIssueEntity> page3 = new PageImpl<>(
+                expiredCoupons.subList(20, 25),
+                PageRequest.of(2, 10),
+                25
+        );
+
+        when(couponIssueRepository.findExpiredCouponsWithPaging(any(LocalDateTime.class), any(Pageable.class)))
+                .thenReturn(page1, page2, page3);
+
+        when(couponIssueRepository.updateToExpiredBatch(anyList(), any(LocalDateTime.class)))
+                .thenReturn(10, 10, 5);
+
+        // when
+        scheduler.processExpiredCoupons();
+
+        // then
+        verify(couponIssueRepository, times(3))
+                .findExpiredCouponsWithPaging(any(LocalDateTime.class), any(Pageable.class));
+        verify(couponIssueRepository, times(3))
+                .updateToExpiredBatch(anyList(), any(LocalDateTime.class));
+
+        // 배치 업데이트에 전달된 ID 검증
+        ArgumentCaptor<List<Long>> idsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(couponIssueRepository, times(3))
+                .updateToExpiredBatch(idsCaptor.capture(), any(LocalDateTime.class));
+
+        List<List<Long>> capturedIds = idsCaptor.getAllValues();
+        assertThat(capturedIds.get(0)).hasSize(10); // 첫 번째 배치
+        assertThat(capturedIds.get(1)).hasSize(10); // 두 번째 배치
+        assertThat(capturedIds.get(2)).hasSize(5);  // 세 번째 배치
+    }
+
+    @Test
+    @DisplayName("스케줄러가 비활성화되면 처리하지 않아야 한다")
+    void processExpiredCoupons_shouldNotProcessWhenDisabled() {
+        // given
+        ReflectionTestUtils.setField(scheduler, "schedulerEnabled", false);
+
+        // when
+        scheduler.processExpiredCoupons();
+
+        // then
+        verify(couponIssueRepository, never())
+                .findExpiredCouponsWithPaging(any(), any());
+        verify(couponIssueRepository, never())
+                .updateToExpiredBatch(anyList(), any());
+    }
+
+    @Test
+    @DisplayName("빈 페이지는 처리하지 않아야 한다")
+    void processExpiredCoupons_shouldHandleEmptyPages() {
+        // given
+        Page<CouponIssueEntity> emptyPage = Page.empty();
+
+        when(couponIssueRepository.findExpiredCouponsWithPaging(any(), any()))
+                .thenReturn(emptyPage);
+
+        // when
+        scheduler.processExpiredCoupons();
+
+        // then
+        verify(couponIssueRepository, times(1))
+                .findExpiredCouponsWithPaging(any(), any());
+        verify(couponIssueRepository, never())
+                .updateToExpiredBatch(anyList(), any());
+    }
+
+    @Test
+    @DisplayName("수동 실행이 정상 동작해야 한다")
+    void processExpiredCouponsManually_shouldWork() {
+        // given
+        List<CouponIssueEntity> expiredCoupons = createExpiredCoupons(5);
+        Page<CouponIssueEntity> page = new PageImpl<>(expiredCoupons);
+
+        when(couponIssueRepository.findExpiredCouponsWithPaging(any(), any()))
+                .thenReturn(page);
+        when(couponIssueRepository.updateToExpiredBatch(anyList(), any()))
+                .thenReturn(5);
+
+        // when
+        int processedCount = scheduler.processExpiredCouponsManually();
+
+        // then
+        assertThat(processedCount).isEqualTo(5);
+        verify(couponIssueRepository).findExpiredCouponsWithPaging(any(), any());
+        verify(couponIssueRepository).updateToExpiredBatch(anyList(), any());
+    }
+
+    @Test
+    @DisplayName("예약 타임아웃 처리가 정상 동작해야 한다")
+    void processReservationTimeouts_shouldRollbackTimedOutReservations() {
+        // given
+        LocalDateTime thirtyMinutesAgo = LocalDateTime.now().minusMinutes(31);
+        List<CouponIssueEntity> timeoutReservations = IntStream.range(1, 6)
+                .mapToObj(i -> {
+                    CouponIssueEntity entity = CouponIssueEntity.builder()
+                            .id((long) i)
+                            .status(CouponStatus.RESERVED)
+                            .reservationId("RESV-" + i)
+                            .reservedAt(thirtyMinutesAgo)
+                            .build();
+                    return entity;
+                })
+                .collect(Collectors.toList());
+
+        when(couponIssueRepository.findTimeoutReservations(any(LocalDateTime.class)))
+                .thenReturn(timeoutReservations);
+
+        // when
+        scheduler.processReservationTimeouts();
+
+        // then
+        verify(couponIssueRepository).findTimeoutReservations(any(LocalDateTime.class));
+        verify(couponIssueRepository, times(5)).save(any(CouponIssueEntity.class));
+
+        // 롤백 상태 검증
+        ArgumentCaptor<CouponIssueEntity> entityCaptor = ArgumentCaptor.forClass(CouponIssueEntity.class);
+        verify(couponIssueRepository, times(5)).save(entityCaptor.capture());
+
+        List<CouponIssueEntity> capturedEntities = entityCaptor.getAllValues();
+        capturedEntities.forEach(entity -> {
+            assertThat(entity.getStatus()).isEqualTo(CouponStatus.ISSUED);
+            assertThat(entity.getReservationId()).isNull();
+            assertThat(entity.getReservedAt()).isNull();
+        });
+    }
+
+    @Test
+    @DisplayName("대량의 만료 쿠폰도 효율적으로 처리해야 한다")
+    void processExpiredCoupons_shouldHandleLargeVolume() {
+        // given
+        int totalCoupons = 1000;
+        int batchSize = 100;
+        ReflectionTestUtils.setField(scheduler, "batchSize", batchSize);
+
+        List<CouponIssueEntity> allCoupons = createExpiredCoupons(totalCoupons);
+
+        // Mockito의 Answer를 사용하여 동적으로 페이지 반환
+        when(couponIssueRepository.findExpiredCouponsWithPaging(any(LocalDateTime.class), any(Pageable.class)))
+                .thenAnswer(invocation -> {
+                    Pageable pageable = invocation.getArgument(1);
+                    int pageNumber = pageable.getPageNumber();
+                    int pageSize = pageable.getPageSize();
+
+                    int start = pageNumber * pageSize;
+                    int end = Math.min(start + pageSize, totalCoupons);
+
+                    if (start >= totalCoupons) {
+                        return Page.empty();
+                    }
+
+                    return new PageImpl<>(
+                            allCoupons.subList(start, end),
+                            pageable,
+                            totalCoupons
+                    );
+                });
+
+        when(couponIssueRepository.updateToExpiredBatch(anyList(), any(LocalDateTime.class)))
+                .thenReturn(batchSize);
+
+        // when
+        scheduler.processExpiredCoupons();
+
+        // then
+        // 1000개를 100개씩 나누면 10개 페이지가 나오고, 마지막에 빈 페이지를 확인하므로 총 10번 호출
+        verify(couponIssueRepository, times(10))
+                .findExpiredCouponsWithPaging(any(LocalDateTime.class), any(Pageable.class));
+        verify(couponIssueRepository, times(10))
+                .updateToExpiredBatch(anyList(), any(LocalDateTime.class));
+    }
+
+    @Test
+    @DisplayName("스케줄러 상태 조회가 정상 동작해야 한다")
+    void getStatus_shouldReturnCorrectStatus() {
+        // given
+        ReflectionTestUtils.setField(scheduler, "schedulerEnabled", true);
+        ReflectionTestUtils.setField(scheduler, "batchSize", 50);
+
+        // when
+        CouponExpiryScheduler.SchedulerStatus status = scheduler.getStatus();
+
+        // then
+        assertThat(status.isEnabled()).isTrue();
+        assertThat(status.getBatchSize()).isEqualTo(50);
+        assertThat(status.getLastProcessedTime()).isNotNull();
+    }
+
+    /**
+     * 테스트용 만료 쿠폰 생성
+     */
+    private List<CouponIssueEntity> createExpiredCoupons(int count) {
+        LocalDateTime expiredTime = LocalDateTime.now().minusDays(1);
+
+        return IntStream.range(1, count + 1)
+                .mapToObj(i -> CouponIssueEntity.builder()
+                        .id((long) i)
+                        .policyId(1L)
+                        .userId((long) (100 + i))
+                        .status(CouponStatus.ISSUED)
+                        .issuedAt(LocalDateTime.now().minusDays(30))
+                        .expiresAt(expiredTime)
+                        .build())
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## Summary
- 만료된 쿠폰 상태 자동 업데이트 스케줄러 구현
- 예약 타임아웃 처리 기능 추가
- **중요**: 만료된 쿠폰도 DB에서 삭제하지 않고 상태만 EXPIRED로 변경

## Changes
### 1. 쿠폰 만료 스케줄러
- `CouponExpiryScheduler` 클래스 추가
- 매일 자정 실행 (설정 가능)
- 배치 처리로 성능 최적화

### 2. 예약 타임아웃 처리
- 30분 경과한 예약 쿠폰 자동 복구
- 5분마다 실행
- RESERVED → ISSUED 상태로 변경

### 3. 배치 업데이트 최적화
- 페이징을 통한 메모리 효율적 처리
- 배치 크기 설정 가능 (기본 100개)
- 대량 데이터 안정적 처리

### 4. Repository 메서드 추가
- `findExpiredCouponsWithPaging()`: 만료 쿠폰 페이징 조회
- `updateToExpiredBatch()`: 배치 상태 업데이트
- Entity에 `rollback()`, `expire()` 메서드 추가

## Configuration
```yaml
coupon:
  scheduler:
    expiry:
      enabled: true
      batch-size: 100
      cron: "0 0 0 * * *"  # 매일 자정
    reservation-timeout:
      enabled: true
      cron: "0 */5 * * * *"  # 5분마다
```

## Test Plan
- [x] `CouponExpirySchedulerTest` 작성
- [x] 배치 처리 검증
- [x] 대량 데이터 처리 테스트 (1000개)
- [x] 예약 타임아웃 처리 검증
- [x] 모든 테스트 통과

## Important Notes
✅ **데이터 보존**: 만료된 쿠폰을 삭제하지 않고 상태만 변경
✅ **성능 최적화**: 배치 처리로 대량 데이터 효율적 처리
✅ **자동 복구**: 타임아웃된 예약 쿠폰 자동 복구